### PR TITLE
Set `useUnifiedTopology` to avoid deprecation warning

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -45,7 +45,7 @@ export class MongoStateStore {
   ): Promise<void> {
     let client: MongoClient | null = null;
     try {
-      client = await MongoClient.connect(this.mongodbHost, { useNewUrlParser: true });
+      client = await MongoClient.connect(this.mongodbHost, { useNewUrlParser: true, useUnifiedTopology: true });
       const db = client.db();
       const result = await actionCallback(db);
       fn(undefined, result);

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@shelf/jest-mongodb": "^1.1.5",
     "@types/jest": "^25.2.1",
-    "@types/mongodb": "^3.1.28",
+    "@types/mongodb": "^3.2",
     "@typescript-eslint/eslint-plugin": "^2.30.0",
     "@typescript-eslint/parser": "^2.30.0",
     "eslint": "^6.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -623,10 +623,10 @@
   dependencies:
     "@types/node" "*"
 
-"@types/mongodb@^3.1.28":
-  version "3.1.28"
-  resolved "https://registry.yarnpkg.com/@types/mongodb/-/mongodb-3.1.28.tgz#c049cdff343788d77f5cc8c5f2e4af72ba7d047b"
-  integrity sha512-tG+QqJ/hir2p0069ee28t2O9tlGRJKDq1WFZC2QYMlU47LGdldLL8tepfTq6aFLvP58OpwSoxaJ/qjW93ob1NQ==
+"@types/mongodb@^3.2":
+  version "3.5.27"
+  resolved "https://registry.yarnpkg.com/@types/mongodb/-/mongodb-3.5.27.tgz#158a7a43ce25ef3592ac8a62e62ab38bebf661f2"
+  integrity sha512-1jxKDgdfJEOO9zp+lv43p8jOqRs02xPrdUTzAZIVK9tVEySfCEmktL2jEu9A3wOBEOs18yKzpVIKUh8b8ALk3w==
   dependencies:
     "@types/bson" "*"
     "@types/node" "*"


### PR DESCRIPTION
Eliminates console log `(node:1924) DeprecationWarning: current Server Discovery and Monitoring engine is deprecated, and will be removed in a future version. To use the new Server Discover and Monitoring engine, pass option { useUnifiedTopology: true } to the MongoClient constructor.`